### PR TITLE
fix: Expand E2E Test Coverage

### DIFF
--- a/fix_10.py
+++ b/fix_10.py
@@ -1,0 +1,73 @@
+// tests/e2e.test.ts
+
+import { expect } from 'chai';
+import { setupTestEnvironment, teardownTestEnvironment } from './setup';
+import { startRelay, startProvider, startConsumer } from '../src/cli';
+import { sleep } from '../src/utils';
+
+describe('E2E Tests', () => {
+  let relayProcess: any;
+  let providerProcess: any;
+  let consumerProcess: any;
+
+  beforeEach(async () => {
+    await setupTestEnvironment();
+    relayProcess = await startRelay();
+    providerProcess = await startProvider();
+  });
+
+  afterEach(async () => {
+    await teardownTestEnvironment();
+    if (relayProcess) relayProcess.kill();
+    if (providerProcess) providerProcess.kill();
+    if (consumerProcess) consumerProcess.kill();
+  });
+
+  it('should handle auth failure with bad signing key', async () => {
+    // Start consumer with a bad signing key
+    consumerProcess = await startConsumer({ signingKey: 'invalid-key' });
+
+    // Wait for consumer to attempt connection
+    await sleep(2000);
+
+    // Check if consumer received an error
+    expect(consumerProcess.stderr).to.include('Authentication failed');
+  });
+
+  it('should handle provider offline scenario', async () => {
+    // Kill provider process
+    providerProcess.kill();
+
+    // Start consumer
+    consumerProcess = await startConsumer();
+
+    // Wait for consumer to attempt connection
+    await sleep(2000);
+
+    // Check if consumer received an error
+    expect(consumerProcess.stderr).to.include('Provider is offline');
+  });
+
+  it('should verify encryption and prevent plaintext prompt', async () => {
+    // Start consumer
+    consumerProcess = await startConsumer();
+
+    // Wait for consumer to send encrypted prompt
+    await sleep(2000);
+
+    // Check if relay received encrypted data
+    expect(relayProcess.stdout).to.include('Encrypted prompt received');
+    expect(relayProcess.stdout).to.not.include('plaintext prompt');
+  });
+
+  it('should handle streaming SSE chunks end-to-end', async () => {
+    // Start consumer
+    consumerProcess = await startConsumer();
+
+    // Wait for consumer to receive streaming data
+    await sleep(5000);
+
+    // Check if consumer received streaming data
+    expect(consumerProcess.stdout).to.include('Streaming data received');
+  });
+});


### PR DESCRIPTION
## Fix for #10: Expand E2E Test Coverage

```typescript
// tests/e2e.test.ts

import { expect } from 'chai';
import { setupTestEnvironment, teardownTestEnvironment } from './setup';
import { startRelay, startProvider, startConsumer } from '../src/cli';
import { sleep } from '../src/utils';

describe('E2E Tests', () => {
  let relayProcess: any;
  let providerProcess: any;
  let consumerProcess: any;

  beforeEach(async () => {
    await setupTestEnvironment();
    relayProcess = await startRelay();
    providerProcess = await startProvider();
  });

  afterEach(async () => {
    await teardownTestEnvironment();
    if (relayProcess) relayProcess.kill();
    if (providerProcess) providerProcess.kill();
    if (consumerProcess) consumerProcess.kill();
  });

  it('should handle auth failure with bad signing key', async () => {
    // Start consumer with a bad signing key
    consumerProcess = await startConsumer({ signingKey: 'invalid-key' });

    // Wait for consumer to attempt connection
    await sleep(2000);

    // Check if consumer received an error
    expect(consumerProcess.stderr).to.include('Authentication failed');
  });

  it('should handle provider offline scenario', async () => {
    // Kill provider process
    providerProcess.kill();

    // Start consumer
    consumerProcess = await startConsumer();

    // Wait for consumer to attempt connection
    await sleep(2000);

    // Check if consumer received an error
    expect(consumerProcess.stderr).to.include('Provider is offline');
  });

  it('should verify encryption and prevent plaintext prompt', async () => {
    // Start consumer
    consumerProcess = await startConsumer();

    // Wait for consumer to send encrypted prompt
    await sleep(2000);

    // Check if relay received encrypted data
    expect(relayProcess.stdout).to.include('Encrypted prompt received');
    expect(relayProcess.stdout).to.not.include('plaintext prompt');
  });

  it('should handle streaming SSE chunks end-to-end', async () => {
    // Start consumer
    consumerProcess = await startConsumer();

    // Wait for consumer to receive streaming data
    await sleep(5000);

    // Check if consumer received streaming data
    expect(consumerProcess.stdout).to.include('Streaming data received');
  });
});
```

### Explanation of Changes:
1. **Auth Failure Test**: Added a test case to handle an invalid signing key scenario. The consumer is started with an invalid key, and the test checks if the consumer receives an authentication failure error.
2. **Provider Offline Test**: Added a test case to simulate the provider being offline. The provider process is killed, and the consumer is started to check if it receives an error indicating the provider is offline.
3. **Encryption Verification Test**: Added a test case to verify that the relay does not receive plaintext prompts. The consumer sends an encrypted prompt, and the test checks if the relay logs that it received encrypted data.
4. **Streaming Test**: Added a test case to verify end-to-end streamin

---
Closes #10