### PR TITLE
fix: Crypto Input Validation — Key Format + Hex Checks

### DIFF
--- a/fix_24.py
+++ b/fix_24.py
@@ -1,0 +1,46 @@
+// src/crypto/index.ts
+
+import * as nacl from 'tweetnacl';
+import { isHexString } from 'hex-regex';
+
+function validatePublicKey(key: Uint8Array, type: string): void {
+  if (key.length !== 32) {
+    throw new Error(`Invalid ${type} key length: expected 32 bytes, got ${key.length} bytes`);
+  }
+}
+
+function fromHex(hex: string): Uint8Array {
+  if (!isHexString(hex) || hex.length % 2 !== 0) {
+    throw new Error(`Invalid hex: ${hex}`);
+  }
+  return new Uint8Array(Buffer.from(hex, 'hex'));
+}
+
+function sign(secretKey: Uint8Array, message: Uint8Array): Uint8Array {
+  if (secretKey.length !== 64) {
+    throw new Error(`Invalid secretKey length: expected 64 bytes, got ${secretKey.length} bytes`);
+  }
+  return nacl.sign(message, secretKey);
+}
+
+function verify(publicKey: Uint8Array, message: Uint8Array, signature: Uint8Array): boolean {
+  validatePublicKey(publicKey, 'public');
+  return nacl.sign.detached.verify(message, signature, publicKey);
+}
+
+function seal(publicKey: Uint8Array, message: Uint8Array): Uint8Array {
+  validatePublicKey(publicKey, 'encryption');
+  return nacl.box(message, nacl.randomBytes(nacl.box.nonceLength), publicKey, nacl.randomBytes(nacl.box.secretKeyLength));
+}
+
+function open(secretKey: Uint8Array, sealedData: Uint8Array, nonce: Uint8Array, publicKey: Uint8Array): Uint8Array | null {
+  if (secretKey.length !== 32) {
+    throw new Error(`Invalid secretKey length: expected 32 bytes, got ${secretKey.length} bytes`);
+  }
+  if (sealedData.length < nacl.box.overheadLength) {
+    throw new Error(`Invalid sealed data length: expected at least ${nacl.box.overheadLength} bytes, got ${sealedData.length} bytes`);
+  }
+  return nacl.box.open(sealedData, nonce, publicKey, secretKey);
+}
+
+export { fromHex, sign, verify, seal, open };


### PR DESCRIPTION
## Fix for #24: Crypto Input Validation — Key Format + Hex Checks

```typescript
// src/crypto/index.ts

import * as nacl from 'tweetnacl';
import { isHexString } from 'hex-regex';

function validatePublicKey(key: Uint8Array, type: string): void {
  if (key.length !== 32) {
    throw new Error(`Invalid ${type} key length: expected 32 bytes, got ${key.length} bytes`);
  }
}

function fromHex(hex: string): Uint8Array {
  if (!isHexString(hex) || hex.length % 2 !== 0) {
    throw new Error(`Invalid hex: ${hex}`);
  }
  return new Uint8Array(Buffer.from(hex, 'hex'));
}

function sign(secretKey: Uint8Array, message: Uint8Array): Uint8Array {
  if (secretKey.length !== 64) {
    throw new Error(`Invalid secretKey length: expected 64 bytes, got ${secretKey.length} bytes`);
  }
  return nacl.sign(message, secretKey);
}

function verify(publicKey: Uint8Array, message: Uint8Array, signature: Uint8Array): boolean {
  validatePublicKey(publicKey, 'public');
  return nacl.sign.detached.verify(message, signature, publicKey);
}

function seal(publicKey: Uint8Array, message: Uint8Array): Uint8Array {
  validatePublicKey(publicKey, 'encryption');
  return nacl.box(message, nacl.randomBytes(nacl.box.nonceLength), publicKey, nacl.randomBytes(nacl.box.secretKeyLength));
}

function open(secretKey: Uint8Array, sealedData: Uint8Array, nonce: Uint8Array, publicKey: Uint8Array): Uint8Array | null {
  if (secretKey.length !== 32) {
    throw new Error(`Invalid secretKey length: expected 32 bytes, got ${secretKey.length} bytes`);
  }
  if (sealedData.length < nacl.box.overheadLength) {
    throw new Error(`Invalid sealed data length: expected at least ${nacl.box.overheadLength} bytes, got ${sealedData.length} bytes`);
  }
  return nacl.box.open(sealedData, nonce, publicKey, secretKey);
}

export { fromHex, sign, verify, seal, open };
```

```typescript
// tests/crypto.test.ts

import { fromHex, sign, verify, seal, open } from '../src/crypto/index';

describe('Crypto Functions', () => {
  const secretKey = nacl.sign.keyPair().secretKey;
  const publicKey = nacl.sign.keyPair().publicKey;
  const message = new Uint8Array([1, 2, 3, 4, 5]);
  const nonce = nacl.randomBytes(nacl.box.nonceLength);

  it('should throw error for invalid hex string', () => {
    expect(() => fromHex('123')).toThrow('Invalid hex: 123');
    expect(() => fromHex('123g')).toThrow('Invalid hex: 123g');
  });

  it('should throw error for invalid secretKey length in sign', () => {
    expect(() => sign(new Uint8Array(32), message)).toThrow('Invalid secretKey length: expected 64 bytes, got 32 bytes');
  });

  it('should throw error for invalid publicKey length in verify', () => {
    expect(() => verify(new Uint8Array(64), message, new Uint8Array(64))).toThrow('Invalid public key length: expected 32 bytes, got 64 bytes');
  });

  it('should throw error for invalid publicKey length in seal', () => {
    expect(() => seal(new Uint8Array(64), message)).toThrow('Invalid encryption key length: expected 32 bytes, got 64 bytes');
  });

  it('should throw error for invalid s

---
Closes #24